### PR TITLE
Add php-smbclient to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN /bin/bash -c "export DEBIAN_FRONTEND=noninteractive" && \
 	php-apcu \
 	php-ldap \
 	php-pgsql \
+	php-smbclient \
 	wget \
 	pwgen \
 	sudo \


### PR DESCRIPTION
This commit adds the Ubuntu package `php-smbclient` to the list of packages that get installed in the Dockerfile. This makes the External Storage functionality for SMB shares possible.

- fixes #4