### PR TITLE
Abort joinscript if udm commands fail

### DIFF
--- a/inst.sh
+++ b/inst.sh
@@ -212,7 +212,7 @@ nextcloud_ensure_extended_attributes () {
     univention-directory-manager settings/extended_attribute modify "$@" \
         --dn "cn=nextcloudUserEnabled,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
         --set tabAdvanced='1' \
-        --set default="1"
+        --set default="1" || die
 
     univention-directory-manager settings/extended_attribute create "$@" \
         --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="users/user" \
@@ -239,8 +239,8 @@ nextcloud_ensure_extended_attributes () {
         --set doNotSearch='0' \
         --set hook='None' || \
     univention-directory-manager settings/extended_attribute modify "$@" \
-		--dn "cn=nextcloudUserQuota,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1'
+        --dn "cn=nextcloudUserQuota,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
+        --set tabAdvanced='1' || die
 
     univention-directory-manager settings/extended_attribute create "$@" \
         --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="groups/group" \
@@ -267,8 +267,8 @@ nextcloud_ensure_extended_attributes () {
         --set doNotSearch='0' \
         --set hook='None' || \
     univention-directory-manager settings/extended_attribute modify "$@" \
-		--dn "cn=nextcloudGroupEnabled,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1'
+        --dn "cn=nextcloudGroupEnabled,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
+        --set tabAdvanced='1' || die
 }
 
 # Enables all Users that fit the filter to access Nextcloud
@@ -287,7 +287,7 @@ nextcloud_modify_users() {
 }
 
 nextcloud_mark_initial_conig_done() {
-    touch "/var/lib/univention-appcenter/apps/nextcloud/conf/initial_config_done"
+    touch "/var/lib/univention-appcenter/apps/nextcloud/conf/initial_config_done" || die
 }
 
 nextcloud_main "$@"


### PR DESCRIPTION
The `udm` (`univention-directory-manager`) commands to create the attributes are essential for the LDAP integration. If these `udm` commands fail for some reason, the joinscript should abort.

This commit calls the function `die` if the Nextcloud specific attributes could neither be created nor modified via `udm`. `die` is sourced from `/usr/share/univention-join/joinscripthelper.lib` and just calls `exit $?`.

This commit also adds the `... || die` switch to the creation of the `initial_config_done` trigger file.
Additionally, some tabs are replaced with spaces.

I decided to not apply the `... || die` switch to the `udm` call that enables all the users. I consider this one not essential enough to make it fail hard. If the creation of the attributes was successful before, but enabling the users automatically fails, the administrator can easily enable the users afterwards manually (or script it). Additionally: consider we have 25.000 users. Calling `udm users/user list` and iterating over them takes some time. In this timeframe, users could be deleted or moved and then the `udm` command fails. Imho, this should not abort the whole joinscript.