### PR TITLE
Add php-mcrypt to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN /bin/bash -c "export DEBIAN_FRONTEND=noninteractive" && \
 	php-ldap \
 	php-pgsql \
 	php-smbclient \
+	php-mcrypt \
 	wget \
 	pwgen \
 	sudo \


### PR DESCRIPTION
This PR adds `php-mcrypt`, which is required to activate the SAML app, to the dockerfile.
The user currently needs to install `php-mcrypt` manually in the container, if they want to use SAML.