### PR TITLE
 Add php-imagick to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN /bin/bash -c "export DEBIAN_FRONTEND=noninteractive" && \
 	php-curl \
 	php-dompdf \
 	php-gd \
+        php-imagick \
 	php-mbstring \
 	php-xml \
 	php-xml-serializer \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN /bin/bash -c "export DEBIAN_FRONTEND=noninteractive" && \
 	php-curl \
 	php-dompdf \
 	php-gd \
-        php-imagick \
+	php-imagick \
 	php-mbstring \
 	php-xml \
 	php-xml-serializer \


### PR DESCRIPTION
This PR adds `php-imagick`, which is required for some functionality of the theming app, to the Dockerfile.
The user currently needs to install  `php-imagick` manually in the container.

The package also has some dependencies:
<pre>
root@nextc-94260413:/# apt install php-imagick
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  ghostscript gsfonts imagemagick-common libcupsfilters1 libcupsimage2 libfftw3-double3 libglib2.0-0 libglib2.0-data libgomp1 libgs9 libgs9-common libijs-0.35 libjbig2dec0 liblcms2-2 liblqr-1-0 libltdl7 libmagickcore-6.q16-2
  libmagickwand-6.q16-2 libpaper-utils libpaper1 libxext6 poppler-data shared-mime-info ttf-dejavu-core xdg-user-dirs
Suggested packages:
  ghostscript-x hpijs libfftw3-bin libfftw3-dev fonts-droid texlive-lang-cjk liblcms2-utils libmagickcore-6.q16-2-extra poppler-utils fonts-japanese-mincho | fonts-ipafont-mincho fonts-japanese-gothic | fonts-ipafont-gothic
  fonts-arphic-ukai fonts-arphic-uming fonts-nanum
The following NEW packages will be installed:
  ghostscript gsfonts imagemagick-common libcupsfilters1 libcupsimage2 libfftw3-double3 libglib2.0-0 libglib2.0-data libgomp1 libgs9 libgs9-common libijs-0.35 libjbig2dec0 liblcms2-2 liblqr-1-0 libltdl7 libmagickcore-6.q16-2
  libmagickwand-6.q16-2 libpaper-utils libpaper1 libxext6 php-imagick poppler-data shared-mime-info ttf-dejavu-core xdg-user-dirs
0 upgraded, 26 newly installed, 0 to remove and 0 not upgraded.
Need to get 14.9 MB of archives.
After this operation, 58.5 MB of additional disk space will be used.
Do you want to continue? [Y/n]
</pre>