### PR TITLE
Fix config path in store_data

### DIFF
--- a/store_data
+++ b/store_data
@@ -21,6 +21,6 @@
 
 NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/conf"
 
-if [ -e "/var/www/html/nextcloud/config/config.php" ]; then
+if [ -e "/var/www/html/config/config.php" ]; then
     cp -Ra "/var/www/html/config" "$NC_PERMCONFDIR/"
 fi


### PR DESCRIPTION
As described in #60, manual changes to the config inside the container at `/var/www/html/config/config.php` are lost when the app is upgraded.

@blizzz  told me that the store_data script is supposed to copy the config file `/var/www/html/config/config.php` to the persistent folder `/var/lib/univention-appcenter/apps/nextcloud/conf/config/`. I have had a look at store_data and found that the path to the config file which is being checked in the if condition before the cp command is wrong. It checks for config.php in `/var/www/html/nextcloud/config/`. That folder does not exist, the config.php is located at `/var/www/html/config/`. The other scripts have the right paths, which is probably why copying back the config at  `/var/lib/univention-appcenter/apps/nextcloud/conf/config/` into `/var/www/html/config/` works as intended.