### PR TITLE
Changes for online offices

### DIFF
--- a/inst
+++ b/inst
@@ -350,7 +350,7 @@ detect_collabora () {
     if [ "$(ucr get appcenter/apps/collabora/status)" = "installed" ] || [ "$(ucr get appcenter/apps/collabora-online/status)" = "installed" ] ; then
         univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:enable richdocuments
         occCode=$?
-        if [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get richdocuments wopi_url)" = "" ] && [ ${occCode} -eq 0 ] ; then
+        if [ ${occCode} -eq 0 ] && [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get richdocuments wopi_url)" = "" ] ; then
             univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:set richdocuments wopi_url --value="https://$FQDN/"
         fi
     else
@@ -367,7 +367,7 @@ detect_onlyoffice () {
     if [ "$(ucr get appcenter/apps/onlyoffice-ds/status)" = "installed" ] ; then
         univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:enable onlyoffice
         occCode=$?
-        if [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get onlyoffice DocumentServerUrl)" = "" ] && [ ${occCode} -eq 0 ] ; then
+        if [ ${occCode} -eq 0 ] && [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get onlyoffice DocumentServerUrl)" = "" ] ; then
             univention-app shell nextcloud occ config:app:set onlyoffice DocumentServerUrl --value="https://$FQDN/onlyoffice-documentserver"
         fi
     else

--- a/inst
+++ b/inst
@@ -353,8 +353,6 @@ detect_collabora () {
         if [ ${occCode} -eq 0 ] && [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get richdocuments wopi_url)" = "" ] ; then
             univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:set richdocuments wopi_url --value="https://$FQDN/"
         fi
-    else
-        univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:disable richdocuments
     fi
 }
 
@@ -370,8 +368,6 @@ detect_onlyoffice () {
         if [ ${occCode} -eq 0 ] && [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get onlyoffice DocumentServerUrl)" = "" ] ; then
             univention-app shell nextcloud occ config:app:set onlyoffice DocumentServerUrl --value="https://$FQDN/onlyoffice-documentserver"
         fi
-    else
-        univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:disable onlyoffice
     fi
 }
 

--- a/inst
+++ b/inst
@@ -62,7 +62,8 @@ nextcloud_main() {
 }
 
 nextcloud_appliance_detection() {
-    if [ "`ucr get umc/web/appliance/id`" = "nextcloud" ]; then
+    appliance_id = $(ucr get umc/web/appliance/id)
+    if [ "$appliance_id" = "nextcloud" ] || [ "$appliance_id" = "collabora" ] || [ "$appliance_id" = "collabora-online" ] || [ "$appliance_id" = "onlyoffice-ds" ]; then
         # On appliance mode, the server works with a preliminary, unknown cert
         NC_ADDITIONAL_CURL_ARGS="--insecure"
     fi

--- a/inst
+++ b/inst
@@ -57,6 +57,8 @@ nextcloud_main() {
     nextcloud_add_Administrator_to_admin_group
     nextcloud_mark_initial_conig_done
     nextcloud_import_ucs_certificates
+    detect_collabora
+    detect_onlyoffice
     joinscript_save_current_version
     exit 0
 }
@@ -337,6 +339,40 @@ nextcloud_curl() {
         exit ${curlCode}
     fi
     echo "$result"
+}
+
+detect_collabora () {
+    # When Collabora (CODE) or Collabora Online is already installed on the UCS system when Nextcloud is going to be installed,
+    # the richdocuments app is enabled and the WOPI URL is configured to the local system, if not already configured.
+    # If the app is not present, the richdocuments app is disabled
+    FQDN="$(ucr get hostname).$(ucr get domainname)"
+    echo "Check for richdocuments app"
+    if [ "$(ucr get appcenter/apps/collabora/status)" = "installed" ] || [ "$(ucr get appcenter/apps/collabora-online/status)" = "installed" ] ; then
+        univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:enable richdocuments
+        occCode=$?
+        if [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get richdocuments wopi_url)" = "" ] && [ ${occCode} -eq 0 ] ; then
+            univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:set richdocuments wopi_url --value="https://$FQDN/"
+        fi
+    else
+        univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:disable richdocuments
+    fi
+}
+
+detect_onlyoffice () {
+    # When ONLYOFFICE is already installed on the UCS system when Nextcloud is going to be installed,
+    # the onlyoffice app is enabled and the DocumentServerUrl is configured to the local system, if not already configured.
+    # If the app is not present, the onlyoffice app is disabled
+    FQDN="$(ucr get hostname).$(ucr get domainname)"
+    echo "Check for onlyoffice app"
+    if [ "$(ucr get appcenter/apps/onlyoffice-ds/status)" = "installed" ] ; then
+        univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:enable onlyoffice
+        occCode=$?
+        if [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get onlyoffice DocumentServerUrl)" = "" ] && [ ${occCode} -eq 0 ] ; then
+            univention-app shell nextcloud occ config:app:set onlyoffice DocumentServerUrl --value="https://$FQDN/onlyoffice-documentserver"
+        fi
+    else
+        univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:disable onlyoffice
+    fi
 }
 
 nextcloud_main "$@"


### PR DESCRIPTION
The virtual app appliances Collabora with Nextcloud and ONLYOFFICE with Nextcloud, the app needs the following update. When the appliance is setup, a online office app is installed first followed by Nextcloud. The goal is to have a system ready where the system administrator does not have to configure anything in order to have one of the online offices working together with Nextcloud.

This pull requests requires https://github.com/nextcloud/univention-app/pull/63 because it assumes that the respective Nextcloud apps for either online office is already installed in the Docker Image.