### PR TITLE
go for Nextcloud 13.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@
 
 FROM ubuntu:16.04
 
-ADD https://download.nextcloud.com/server/prereleases/nextcloud-13.0.5.tar.bz2 /root/nextcloud.tar.bz2
-ADD https://github.com/nextcloud/richdocuments/archive/2.0.11.tar.gz /root/richdocuments.tar.gz
-ADD https://github.com/ONLYOFFICE/onlyoffice-nextcloud/archive/v2.0.2.tar.gz /root/onlyoffice.tar.gz
+ADD https://download.nextcloud.com/server/prereleases/nextcloud-13.0.6.tar.bz2 /root/nextcloud.tar.bz2
+ADD https://github.com/nextcloud/richdocuments/releases/download/v2.0.12/richdocuments.tar.gz /root/richdocuments.tar.gz
+ADD https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v2.0.2/onlyoffice.tar.gz /root/onlyoffice.tar.gz
 COPY resources/entrypoint.sh /usr/sbin/
 COPY resources/60-nextcloud.ini /etc/php/7.0/apache2/conf.d/
 COPY resources/60-nextcloud.ini /etc/php/7.0/cli/conf.d/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 app_name=nextcloud
-app_version=13.0.5-0
+app_version=13.0.6-0
 
 ucs_version=4.1
 


### PR DESCRIPTION
also updates app links to current releases and actual builds

@ngulden fyi ↑ shouldn't change much though. other that uneceesary development files are not shipped, but possible build steps were executed compared to git-dumps.