### PR TITLE
Add example for quotas to custom attribute's longDescription

### DIFF
--- a/inst
+++ b/inst
@@ -244,9 +244,9 @@ nextcloud_ensure_extended_attributes () {
         --set objectClass='nextcloudUser' \
         --set name='nextcloudUserQuota' \
         --set shortDescription='Nextcloud Quota' \
-        --set longDescription='Amount of storage available to the user' \
+        --set longDescription='Amount of storage available to the user (ex: 512 MB or 12 GB)' \
         --set translationShortDescription='"de_DE" "Nextcloud Quota"' \
-        --set translationLongDescription='"de_DE" "Der verfügbare Speicherplatz für den Benutzer"' \
+        --set translationLongDescription='"de_DE" "Der verfügbare Speicherplatz für den Benutzer (z.B. 512 MB oder 12 GB)"' \
         --set tabName='Nextcloud' \
         --set translationTabName='"de_DE" "Nextcloud"' \
         --set overwriteTab='0' \


### PR DESCRIPTION
A customer recently asked how Nexcloud expects quotas to be specified in the LDAP. I think it would be nice if the small question mark told them. I've made a similar PR to the ownCloud app as well.
This adds the example used in Nextcloud's user management page to the longDescription, which is used for the question mark.