### PR TITLE
Fix automatic setting for ONLYOFFICE document server URL

### DIFF
--- a/inst
+++ b/inst
@@ -367,7 +367,7 @@ detect_onlyoffice () {
         univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:enable onlyoffice
         occCode=$?
         if [ ${occCode} -eq 0 ] && [ "$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:get onlyoffice DocumentServerUrl)" = "" ] ; then
-            univention-app shell nextcloud occ config:app:set onlyoffice DocumentServerUrl --value="https://$FQDN/onlyoffice-documentserver"
+            univention-app shell nextcloud sudo -u www-data /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value="https://$FQDN/onlyoffice-documentserver"
         fi
     fi
 }


### PR DESCRIPTION
The ONLYOFFICE document server URL was not set automatically in the
Nextcloud join script. The error was:

rpc error: code = 2 desc = oci runtime error: exec failed:
container_linux.go:247: starting container process caused "exec:
\"occ\": executable file not found in $PATH"

This is fixed now.