### PR TITLE
Use LDAP base as group base by default

### DIFF
--- a/inst
+++ b/inst
@@ -85,7 +85,7 @@ nextcloud_ensure_ucr() {
             nextcloud/ldap/groupDisplayName?"cn" \
             nextcloud/ldap/base?"$ldap_base" \
             nextcloud/ldap/baseUsers?"$ldap_base" \
-            nextcloud/ldap/baseGroups?"cn=groups,$ldap_base" \
+            nextcloud/ldap/baseGroups?"$ldap_base" \
             nextcloud/ldap/filterLogin?"(&(objectclass=nextcloudUser)(nextcloudEnabled=1)(uid=%uid))" \
             nextcloud/ldap/filterUsers?"(&(objectclass=nextcloudUser)(nextcloudEnabled=1))" \
             nextcloud/ldap/filterGroups?"(&(objectclass=nextcloudGroup)(nextcloudEnabled=1))" \


### PR DESCRIPTION
I'd like to propose changing the LDAP lookup base for groups to `$ldap_base` instead of `cn=groups,$ldap_base` by default in `inst` with this PR. 

`cn=groups,$ldap_base` is problematic as soon as OUs are used, which is the case in every UCS@school installation for example.
When one sets up UCS@school with a school called "s1" and sets up a class "1a", the group object is created below `cn=groups,ou=s1,dc=ldap,dc=base` - outside the current default group base..

Of course the group lookup base can be changed manually with the UCR variable `nextcloud/ldap/baseGroups` but since OUs are such a common use case (or the only one with UCS@school) and the user lookup base is set to the `$ldap_base` as well, I consider this a suitable new default.