### PR TITLE
Leave data in place after uninstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN /bin/bash -c "export DEBIAN_FRONTEND=noninteractive" && \
 	php-dompdf \
 	php-gd \
 	php-imagick \
+	php-intl \
 	php-mbstring \
 	php-xml \
 	php-zip \

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ add-version:
 .PHONY: push-files
 push-files:
 	univention-appcenter-control upload --noninteractive $(app_name)=$(app_version) \
+		env \
 		restore_data_before_setup \
 		setup \
 		restore_data_after_setup \
@@ -50,7 +51,7 @@ push-files:
 		i18n/en/README_INSTALL_EN \
 		i18n/de/README_INSTALL_DE \
 		i18n/en/README_UNINSTALL_EN \
-		i18n/de/README_UNINSTALL_DE
+		i18n/de/README_UNINSTALL_DE \
 	univention-appcenter-control set --noninteractive $(app_name)=$(app_version) \
 		--json '{"DockerImage": "nextcloud/univention-app:$(app_version)"}'
 

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,12 @@ push-files:
 		nextcloud.schema \
 		i18n/en/README_INSTALL_EN \
 		i18n/de/README_INSTALL_DE \
+		i18n/en/README_POST_INSTALL_EN \
+		i18n/de/README_POST_INSTALL_DE \
 		i18n/en/README_UNINSTALL_EN \
 		i18n/de/README_UNINSTALL_DE \
+		i18n/en/README_POST_UPDATE_EN \
+		i18n/de/README_POST_UPDATE_DE
 	univention-appcenter-control set --noninteractive $(app_name)=$(app_version) \
 		--json '{"DockerImage": "nextcloud/univention-app:$(app_version)"}'
 

--- a/env
+++ b/env
@@ -1,0 +1,4 @@
+NC_PERMDATADIR=/var/lib/univention-appcenter/apps/nextcloud/data
+NC_PERMCONFDIR=/var/lib/univention-appcenter/apps/nextcloud/data/integration
+NC_PERMCONFDIR_OLD=/var/lib/univention-appcenter/apps/nextcloud/conf
+NC_UCR_DOMAIN=@%@hostname@%@.@%@domainname@%@

--- a/i18n/de/README_POST_INSTALL_DE
+++ b/i18n/de/README_POST_INSTALL_DE
@@ -1,0 +1,10 @@
+<p>Glückwunsch, die Nextcloud-Instanz wurde erfolgreich installiert!</p>
+<h2>Hinweise zu Meldungen in der Übersicht der Admineinstellungen</h2>
+<p>Im Bereich der <strong>Sicherheits- & Einrichtungswarnungen</strong> werden wahrscheinlich einige Hinweise angezeigt, mit der die Nextcloud-Installation verbessert werden kann. Diese Punkt können nicht im Rahmen der Nextcloud Integration für UCS erfolgen, stattdessen entscheidet der Administrator gegebenenfalls Schritte durchzuführen.
+<h3>"Strict-Transport-Security" HTTP header</h3>
+<p>Um den Dienst gegen Man-in-the-Middle Attacken zu härten, kann dieser Mechanismus aktiviert werden. Die SSL Terminierung erfolgt auf dem Reverse Proxy, typischer ein Apache2 Webserver auf dem Host. Die Konfiguration für die Domain(s) unter denen Nextcloud betrieben wird, muss dafür um einen HTTP Header ergänzt werden. Wenn diese Änderungen durchgeführt werden, wirken sie sich auf alle Dienste unterhalb der Domain aus.</p>
+<p>This <a href="https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html#enable-http-strict-transport-security">Dokumentation erklärt wie HSTS eingerichtet wird</a>. Der <strong>includeSubDomains</strong>-Schalter ist notwendig.</p>
+<h3>Auflösung von "/.well-known/caldav|carddav" scheitert</h3
+<p>Das Auffinden von Adressbuch- und Kalenderdiensten kann für entsprechende Klienten vereinfacht werden, in dem solche well-known URLs verfügbar gemacht werden, die letztlich auf den tatsächlichen Dienst verweisen. Die anschlagende Überprüfung tested, ob unterhalb der Hauptdomain diese URLs vorhanden sind. Um diese bereit zu stellen muss auch hier der Webserver des Hosts <a href="https://docs.nextcloud.com/server/14/admin_manual/issues/general_troubleshooting.html#service-discovery">anhand dieser Dokumentation</a> angefasst werden.
+<p>Es kann nur jeweils ein Dienst pro Domain verknüpft werden. Das Vorhandensein der URLs ist nicht kritisch für das Funktionieren der Nextcloud, erhöht aber den Komfort für einige Endnutzer.</p>
+<p>Diese Überprüfung ist während der Nextcloud 13 Serie eingeführt worden. In früheren Versionen wurde der Hinweis folglich nicht gezeigt.</p>

--- a/i18n/de/README_POST_UPDATE_DE
+++ b/i18n/de/README_POST_UPDATE_DE
@@ -1,0 +1,14 @@
+<h2>Hinweise zu Meldungen in der Übersicht der Admineinstellungen</h2>
+<p>Im Bereich der <strong>Sicherheits- & Einrichtungswarnungen</strong> werden wahrscheinlich einige Hinweise angezeigt, mit der die Nextcloud-Installation verbessert werden kann. Diese Punkt können nicht im Rahmen der Nextcloud Integration für UCS erfolgen, stattdessen entscheidet der Administrator gegebenenfalls Schritte durchzuführen.
+<h3>"Strict-Transport-Security" HTTP header</h3>
+<p>Um den Dienst gegen Man-in-the-Middle Attacken zu härten, kann dieser Mechanismus aktiviert werden. Die SSL Terminierung erfolgt auf dem Reverse Proxy, typischer ein Apache2 Webserver auf dem Host. Die Konfiguration für die Domain(s) unter denen Nextcloud betrieben wird, muss dafür um einen HTTP Header ergänzt werden. Wenn diese Änderungen durchgeführt werden, wirken sie sich auf alle Dienste unterhalb der Domain aus.</p>
+<p>This <a href="https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html#enable-http-strict-transport-security">Dokumentation erklärt wie HSTS eingerichtet wird</a>. Der <strong>includeSubDomains</strong>-Schalter ist notwendig.</p>
+<h3>Auflösung von "/.well-known/caldav|carddav" scheitert</h3
+<p>Das Auffinden von Adressbuch- und Kalenderdiensten kann für entsprechende Klienten vereinfacht werden, in dem solche well-known URLs verfügbar gemacht werden, die letztlich auf den tatsächlichen Dienst verweisen. Die anschlagende Überprüfung tested, ob unterhalb der Hauptdomain diese URLs vorhanden sind. Um diese bereit zu stellen muss auch hier der Webserver des Hosts <a href="https://docs.nextcloud.com/server/14/admin_manual/issues/general_troubleshooting.html#service-discovery">anhand dieser Dokumentation</a> angefasst werden.
+<p>Es kann nur jeweils ein Dienst pro Domain verknüpft werden. Das Vorhandensein der URLs ist nicht kritisch für das Funktionieren der Nextcloud, erhöht aber den Komfort für einige Endnutzer.</p>
+<p>Diese Überprüfung ist während der Nextcloud 13 Serie eingeführt worden. In früheren Versionen wurde der Hinweis folglich nicht gezeigt.</p>
+<h3>Fehlende Datenbank-Indizes</h3>
+<p>Diese Meldung erscheint nach einem Upgrade von Nextcloud 13. Die Datenbankstruktur hat sich leicht geändert und neue Indizes sind hinzugefügt worden. Theoretisch könnten diese während dem Upgrade-Prozess hinzugefügt werden. Weil dies jedoch insbesondere bei großen Datenbeständen zeitintensiv ist, wird es in dem Rahmen nicht durchgeführt. Die Indizes sind nicht kritisch für die Funktionstüchtigkeit der Nextcloud, verbessern aber die Geschwindigkeit bei relevanten Operationen.</p>
+<p>Folgender Befehl, auszuführen auf dem Host, fügt die Indizes hinzu:</p>
+<p><code>univention-app shell nextcloud sudo -u www-data /var/www/html/occ db:add-missing-indices</code></p>
+<p>Es ist nicht notwendig Nextcloud in den Wartungsmodus zu schalten, diese Aktion kann während des Produktivbetriebs durchgeführt werden.</p>

--- a/i18n/de/README_UNINSTALL_DE
+++ b/i18n/de/README_UNINSTALL_DE
@@ -1,6 +1,19 @@
+<p>Die Deinstallation von Nextcloud behält Anwendungs- und Nutzdaten bei.</p>
 <p>
-Die Deinstallation von Nextcloud wird ebenfalls alle Daten entfernen.
-</p>
-<p>
-Falls diese behalten werden sollen, sollte ein Backup der <i>nextcloud</i> Datenbank aus PostgreSQL sowie vom Datenordner <i>/var/lib/univention-appcenter/apps/nextcloud/data</i> angelegt werden, bevor mit der Deinstallation fortgefahren wird.
-</p>
+Folgende Artefakte bleiben erhalten:
+
+<h3>UCR Variablen</h3>
+<p>Diese können mit folgendem Befehl auf dem Host zurückgesetzt werden:</p>
+<p><code>ucr unset `ucr search --key "^nextcloud" | cut -d ":" -f 1 | grep nextcloud | tr '\n' ' '`</code></p>
+
+<h3>Die Datenbank</h3>
+<p>Mit folgenden Befehlen kann die Datenbank bereinigt werden</p>
+<p><code>su -c "psql -c \"drop database nextcloud\"" - postgres && \
+    su -c "dropuser \"nextcloud\"" - postgres && \
+    rm /etc/postgresql-nextcloud.secret
+</code></p>
+<p>Die erste Befehl löscht die Nextcloud Datenbank in Postgres, der zweite Befehl entfernt den Datenbank-Benutzer. Die Dritte tilgt die Passwortdatei.</p>
+
+<h3>Nextclouds Anwendungsordner</h3>
+<p>Der Anwendungsordner enthält UCS-spezifische Daten, sowie den Nextcloud Datenordner. Folgender Befehl löscht den Ordner</p>
+<p><code>rm -Rf "/var/lib/univention-appcenter/apps/nextcloud"</code></p>

--- a/i18n/en/README_POST_INSTALL_EN
+++ b/i18n/en/README_POST_INSTALL_EN
@@ -1,0 +1,10 @@
+<p>Congratulations, your Nextcloud instance was installed successfully!</p>
+<h2>Notes on messages shown in the admin settings overview</h2>
+<p>In the <strong>Security & setup warnings</strong> section it is likely that some messages are shown, on how to improve the setup. The items mentioned cannot be done by the Nextcloud integration for UCS, instead the admin needs to decide whether actions should be taken.</p>
+<h3>"Strict-Transport-Security" HTTP header</h3>
+<p>To harden the service against man-in-the-middle attacks, this mechanism can be enabled. The SSL termination happens on the reverse proxy, which typically is an Apache2 web server on the host. The configuration for the domain(s) Nextcloud is running on would need to be extended with an HTTP header. Applying the changes affects all services running within this domain.</p>
+<p>This <a href="https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html#enable-http-strict-transport-security">documentation page explains how to configure HSTS</a>. The <strong>includeSubDomains</strong> is necessary.</p>
+<h3>Not able to resolve "/.well-known/caldav|carddav"</h3>
+<p>Discovery of addressbook and calendar services can be made easier for such clients, by providing well-known URLs that redirect to the actual location of that service. This check tests whether the top-level domain has the given URLs present. Again, to resolve this, the web server configuration of the host needs to be adjusted, <a href="https://docs.nextcloud.com/server/14/admin_manual/issues/general_troubleshooting.html#service-discovery">according to this documentation</a>.<p>
+<p>It is only possible to link to one service provider on a domain. Having the URLs present is not crucial for a working Nextcloud setup, but improves the convenience for some end users.</p>
+<p>The check was introduced within the Nextcloud 13 series. Thus in the earlier version the hint was not shown.</p>

--- a/i18n/en/README_POST_UPDATE_EN
+++ b/i18n/en/README_POST_UPDATE_EN
@@ -1,0 +1,14 @@
+<h2>Notes on messages shown in the admin settings overview</h2>
+<p>In the <strong>Security & setup warnings</strong> section it is likely that some messages are shown, on how to improve the setup. The items mentioned cannot be done by the Nextcloud integration for UCS, instead the admin needs to decide whether actions should be taken.</p>
+<h3>"Strict-Transport-Security" HTTP header</h3>
+<p>To harden the service against man-in-the-middle attacks, this mechanism can be enabled. The SSL termination happens on the reverse proxy, which typically is an Apache2 web server on the host. The configuration for the domain(s) Nextcloud is running on would need to be extended with an HTTP header. Applying the changes affects all services running within this domain.</p>
+<p>This <a href="https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html#enable-http-strict-transport-security">documentation page explains how to configure HSTS</a>. The <strong>includeSubDomains</strong> is necessary.</p>
+<h3>Not able to resolve "/.well-known/caldav|carddav"</h3>
+<p>Discovery of addressbook and calendar services can be made easier for such clients, by providing well-known URLs that redirect to the actual location of that service. This check tests whether the top-level domain has the given URLs present. Again, to resolve this, the web server configuration of the host needs to be adjusted, <a href="https://docs.nextcloud.com/server/14/admin_manual/issues/general_troubleshooting.html#service-discovery">according to this documentation</a>.<p>
+<p>It is only possible to link to one service provider on a domain. Having the URLs present is not crucial for a working Nextcloud setup, but improves the convenience for some end users.</p>
+<p>The check was introduced within the Nextcloud 13 series. Thus in the earlier version the hint was not shown.</p>
+<h3>Missing database indices</h3>
+<p>This message would appear after an upgrade from Nextcloud 13. The database structure changed a bit, and new indices were introduced. Theoretically, Nextcloud could add them within the upgrade process, however refrains from it as it can take a significant amount of time. The indices are not crucial for the functioning of Nextcloud, but do increase database performance in corresponding queries.</p>
+<p>To add the indices run the following command from your host:</p>
+<p><code>univention-app shell nextcloud sudo -u www-data /var/www/html/occ db:add-missing-indices</code></p>
+<p>It is not necessary to put Nextcloud into maintenance mode, this action can run during production.</p>

--- a/i18n/en/README_UNINSTALL_EN
+++ b/i18n/en/README_UNINSTALL_EN
@@ -1,4 +1,19 @@
-Uninstalling Nextcloud will also remove all your data.
-<br>
-<br>
-If you want to keep it, back up the <i>nextcloud</i> database in your Postgres Database as well as the <i>/var/lib/univention-appcenter/apps/nextcloud/data</i> folder before continuing uninstalling Nextcloud.
+<p>Uninstalling Nextcloud keeps your data.</p>
+<p>
+Following artifacts are left:
+
+<h3>UCR Variables</h3>
+<p>In order to unset them on your host execute:</p>
+<p><code>ucr unset `ucr search --key "^nextcloud" | cut -d ":" -f 1 | grep nextcloud | tr '\n' ' '`</code></p>
+
+<h3>The database</h3>
+<p>In order to clean up the database, on the host execute:</p>
+<p><code>su -c "psql -c \"drop database nextcloud\"" - postgres && \
+    su -c "dropuser \"nextcloud\"" - postgres && \
+    rm /etc/postgresql-nextcloud.secret
+</code></p>
+<p>The first command drops the Nextcloud database in Postgres, the second one deletes the database user. The third deletes the password file.</p>
+
+<h3>Nextcloud application folder</h3>
+<p>The application folder contains UCS specific data, as well as the Nextcloud data folder inside it. To delete it, execute</p>
+<p><code>rm -Rf "/var/lib/univention-appcenter/apps/nextcloud"</code></p>

--- a/inst
+++ b/inst
@@ -29,7 +29,7 @@ SERVICE="Nextcloud"
 joinscript_init
 eval "$(ucr shell)"
 
-NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/conf"
+NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/data/integration"
 NC_ADMIN_PWD_FILE="$NC_PERMCONFDIR/admin.secret"
 NC_MEMBER_OF=0
 HOST="https://${hostname}.${domainname}/nextcloud"
@@ -40,7 +40,7 @@ NC_LDAP_BIND_PW="$(< $NC_LDAP_BIND_PW_FILE)"
 NC_ADDITIONAL_CURL_ARGS=
 
 nextcloud_main() {
-    if [ -e "/var/lib/univention-appcenter/apps/nextcloud/conf/initial_config_done" ] ; then
+    if [ -e "$NC_PERMCONFDIR/initial_config_done" ] ; then
         IS_UPDATE=true
     fi
     ucs_addServiceToLocalhost "${SERVICE}" "$@"
@@ -322,7 +322,7 @@ nextcloud_import_ucs_certificates () {
 }
 
 nextcloud_mark_initial_conig_done() {
-    touch "/var/lib/univention-appcenter/apps/nextcloud/conf/initial_config_done" || die
+    touch "$NC_PERMCONFDIR/initial_config_done" || die
 }
 
 nextcloud_curl() {

--- a/inst
+++ b/inst
@@ -118,6 +118,7 @@ nextcloud_update_ldap_bind_account() {
 nextcloud_configure_ldap_backend() {
     if [ $IS_UPDATE = true ] ; then
         echo "Not attempting to set LDAP configuration, because NC is already installed and set up."
+        nextcloud_update_ldap_backend_password_if_necessary
         return
     fi
     local NC_ADMIN_PWD=`cat "$NC_ADMIN_PWD_FILE"`
@@ -167,6 +168,22 @@ nextcloud_configure_ldap_backend() {
         $NC_ADDITIONAL_CURL_ARGS \
         "$HOST/ocs/v2.php/apps/user_ldap/api/v1/config/$CONFIGID" \
         || die "Configuring LDAP Backend failed"
+}
+
+nextcloud_update_ldap_backend_password_if_necessary() {
+    # when the original user is configured, update the password to ensure it is set correctly even on a reinstall
+    # that kept the data and config from the previous installation
+    CONFIGID=$(< "$NC_PERMCONFDIR/ldap-config-id")
+    if [[ -z "$CONFIGID" ]]; then
+        return
+    fi
+
+    LDAP_CON_STATE=$(univention-app shell nextcloud sudo -u www-data /var/www/html/occ ldap:test-config $CONFIGID)
+    if [[ "$LDAP_CON_STATE" != "The configuration is valid and the connection could be established!" ]] ; then
+        echo "Updating LDAP bind credentials"
+        univention-app shell nextcloud sudo -u www-data /var/www/html/occ ldap:set-config "$CONFIGID" ldapAgentName "$NC_LDAP_BIND_DN"
+        univention-app shell nextcloud sudo -u www-data /var/www/html/occ ldap:set-config "$CONFIGID" ldapAgentPassword "$NC_LDAP_BIND_PW"
+    fi
 }
 
 nextcloud_add_Administrator_to_admin_group() {

--- a/preinst
+++ b/preinst
@@ -19,7 +19,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/conf"
+NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/data/integration"
+
+# TODO: remove this block once Nc 14 is end of life
+NC_PERMCONFDIR_OLD="/var/lib/univention-appcenter/apps/nextcloud/conf"
+if [ -d "$NC_PERMCONFDIR_OLD" ]; then
+    mv "$NC_PERMCONFDIR_OLD" "$NC_PERMCONFDIR"
+fi
+
 NC_UCR_FILE="$NC_PERMCONFDIR/ucr"
 
 # the folder is not yet created, as expected
@@ -30,9 +37,7 @@ if [ "`ucr get umc/web/appliance/id`" = "nextcloud" ]; then
     APPLIANCE=true
 fi
 
-
 cat >"$NC_UCR_FILE" <<EOL
-export NC_UCR_DOMAIN="`ucr get hostname`"."`ucr get domainname`"
 export NC_HOST_IPS="`ucr dump | grep interfaces | grep address | cut -d ":" -f2`"
 export NC_TRUSTED_PROXY_IP="`ucr get docker/daemon/default/opts/bip | cut -d "/" -f 1`"
 export NC_APPLIANCE=$APPLIANCE

--- a/restore_data_after_setup
+++ b/restore_data_after_setup
@@ -19,8 +19,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/conf"
-
 if [ -e "/var/www/html/config/config.php" ]; then
     cp -Ra "/var/www/html/config" "$NC_PERMCONFDIR/"
+fi
+
+# changed with the upgrade from Nextcloud 13 to 14.0.4
+# TODO: remove this block once Nc 14 is end of life
+if [ -e "$NC_PERMCONFDIR_OLD/config/config.php" ]; then
+    rm "$NC_PERMCONFDIR_OLD/config/config.php"
 fi

--- a/restore_data_before_setup
+++ b/restore_data_before_setup
@@ -26,5 +26,5 @@ if [ -e "$NC_PERMCONFDIR_OLD/config/config.php" ]; then
 fi
 
 if [ -e "$NC_PERMCONFDIR/config/config.php" ]; then
-    cp -a "$NC_PERMCONFDIR/config/*config.php" "/var/www/html/config/"
+    cp -a "$NC_PERMCONFDIR/config/"*config.php "/var/www/html/config/"
 fi

--- a/restore_data_before_setup
+++ b/restore_data_before_setup
@@ -19,8 +19,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/conf"
+# changed with the upgrade from Nextcloud 13 to 14.0.4
+# TODO: remove this block once Nc 14 is end of life
+if [ -e "$NC_PERMCONFDIR_OLD/config/config.php" ]; then
+    cp -a "$NC_PERMCONFDIR_OLD/config/config.php" "/var/www/html/config/"
+fi
 
 if [ -e "$NC_PERMCONFDIR/config/config.php" ]; then
-    cp -a "$NC_PERMCONFDIR/config/config.php" "/var/www/html/config/"
+    cp -a "$NC_PERMCONFDIR/config/*config.php" "/var/www/html/config/"
 fi

--- a/setup
+++ b/setup
@@ -79,7 +79,6 @@ if [ "$NC_IS_UPGRADE" -eq 0 ] ; then
     $OCC config:system:set overwritewbroot --value="/nextcloud"
     $OCC config:system:set overwrite.cli.url --value="https://$NC_UCR_DOMAIN/nextcloud"
     $OCC config:system:set htaccess.RewriteBase --value="/nextcloud"
-    $OCC maintenance:update:htaccess
     $OCC background:cron
     $OCC app:enable user_ldap
     $OCC app:disable updatenotification
@@ -136,6 +135,9 @@ else
         $OCC app:enable "$APPID" || echo "Could not re-enable $APPID"
     done
 fi
+
+# Recreate the htaccess on both install and update
+$OCC maintenance:update:htaccess
 
 # env var is set from the dockerfile
 if [ "$NC_IS_PATCHED" = true ]; then

--- a/setup
+++ b/setup
@@ -19,10 +19,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-NC_PERMDATADIR="/var/lib/univention-appcenter/apps/nextcloud/data"
 NC_DATADIR="$NC_PERMDATADIR/nextcloud-data"
-
-NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/conf"
 NC_UCR_FILE="$NC_PERMCONFDIR/ucr"
 
 cd /var/www/html

--- a/store_data
+++ b/store_data
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/conf"
-
 if [ -e "/var/www/html/config/config.php" ]; then
     cp -Ra "/var/www/html/config" "$NC_PERMCONFDIR/"
 fi

--- a/uinst
+++ b/uinst
@@ -33,17 +33,7 @@ if ucs_isServiceUnused "$SERVICE" "$@"; then
 
     univention-directory-manager container/cn remove "$@" \
         --dn "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" || die
-
-    ucr unset `ucr search --key "^nextcloud" | cut -d ":" -f 1 | grep nextcloud | tr '\n' ' '`
-
 fi
-
-# Remove the database and the user
-su -c "psql -c \"drop database nextcloud\"" - postgres && \
-    su -c "dropuser \"nextcloud\"" - postgres && \
-    rm /etc/postgresql-nextcloud.secret && \
-    # Remove the app folder, including config, data and UCS specific files that would block clean reinstall
-    rm -Rf "/var/lib/univention-appcenter/apps/nextcloud/"
 
 joinscript_remove_script_from_status_file nextcloud
 exit 0


### PR DESCRIPTION
fixes #76 

* delete neither database nor ucr values nor the nextcloud data folder on uninstall anymore
* moves the (integration-)config folder below data in the corresponding univention-app location to be persistent
* updates LDAP credentials on update if the connection test was not successful
* .htaccess is recreated on update too (we have clean urls now and this requires it to still have them after an update)
* adds POST_UNINSTALL, POST_INSTALL and POST_UPDATE Readmes