### PR TITLE
UCS Bug #48621: adjust joinscript for app tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ push-files:
 		uinst \
 		update_app_version \
 		nextcloud.schema \
+		attributes \
 		i18n/en/README_INSTALL_EN \
 		i18n/de/README_INSTALL_DE \
 		i18n/en/README_POST_INSTALL_EN \

--- a/attributes
+++ b/attributes
@@ -1,0 +1,95 @@
+[nextcloudUser]
+Type=ExtendedOption
+ObjectClass=nextcloudUser
+Module=users/user
+Default=1
+Editable=1
+Description=Nextcloud
+DescriptionDE=Nextcloud
+LongDescription=User can access Nextcloud
+LongDescriptionDE=Der Benutzer kann auf Nextcloud zugreifen
+BelongsTo=nextcloudUser
+
+[nextcloudUserEnabled]
+Type=ExtendedAttribute
+Module=users/user
+LdapMapping=nextcloudEnabled
+BelongsTo=nextcloudUser
+Description=Access to Nextcloud
+DescriptionDE=Zugang für Nextloud
+LongDescription=User can access Nextcloud
+LongDescriptionDE=Der Benutzer kann auf Nextcloud zugreifen
+TabName=Nextcloud
+TabNameDE=Nextcloud
+OverwriteTab=0
+Required=0
+CliName=nextcloudEnabled
+UdmSyntax=AppActivatedBoolean
+Default=1
+Advanced=0
+DisableWeb=1
+Options=nextcloudUser
+MayChange=1
+DeleteObjectClass=1
+TabPosition=1
+DontSearch=0
+
+[nextcloudUserQuota]
+Type=ExtendedAttribute
+Module=users/user
+LdapMapping=nextcloudQuota
+BelongsTo=nextcloudUser
+Description=Nextcloud Quota
+DescriptionDE=Nextcloud Quota
+LongDescription=Amount of storage available to the user (ex: 512 MB or 12 GB)
+LongDescriptionDE=Der verfügbare Speicherplatz für den Benutzer (z.B. 512 MB oder 12 GB)
+TabName=Nextcloud
+TabNameDE=Nextcloud
+GroupName=Quota Settings
+GroupNameDE=Quota-Einstellungen
+OverwriteTab=0
+Required=0
+CliName=nextcloudQuota
+UdmSyntax=string
+Default=
+Advanced=0
+Options=nextcloudUser
+MayChange=1
+DeleteObjectClass=0
+TabPosition=1
+DontSearch=0
+
+[nextcloudGroup]
+Type=ExtendedOption
+ObjectClass=nextcloudGroup
+Module=groups/group
+Default=0
+Editable=1
+Description=Nextcloud
+DescriptionDE=Nextcloud
+LongDescription=The group is available in Nextcloud
+LongDescriptionDE=Die Gruppe ist in Nextcloud verfügbar
+BelongsTo=nextcloudGroup
+
+[nextcloudGroupEnabled]
+Type=ExtendedAttribute
+Module=groups/group
+LdapMapping=nextcloudEnabled
+BelongsTo=nextcloudGroup
+Description=Available in Nextcloud
+DescriptionDE=In Nextcloud verfügbar
+LongDescription=The group is available in Nextcloud
+LongDescriptionDE=Die Gruppe ist in Nextcloud verfügbar
+TabName=Nextcloud
+TabNameDE=Nextcloud
+OverwriteTab=0
+Required=0
+CliName=nextcloudEnabled
+UdmSyntax=AppActivatedBoolean
+Default=0
+Options=nextcloudGroup
+Advanced=0
+MayChange=1
+DeleteObjectClass=1
+TabPosition=1
+DontSearch=0

--- a/inst
+++ b/inst
@@ -66,7 +66,6 @@ nextcloud_main() {
     nextcloud_ensure_ucr
     nextcloud_attempt_memberof_support
     joinscript_register_schema "$@"
-    nextcloud_ensure_extended_attributes "$@"
     nextcloud_configure_ldap_backend
     nextcloud_modify_users "$@"
     nextcloud_add_Administrator_to_admin_group
@@ -256,98 +255,6 @@ nextcloud_add_Administrator_to_admin_group() {
 nextcloud_urlEncode() {
   python -c 'import urllib, sys; print urllib.quote(sys.argv[1], sys.argv[2])' \
     "$1" ""
-}
-
-# adds extended attributes to UCS so admins can enable or disable Nextcloud access for users and groups
-nextcloud_ensure_extended_attributes () {
-    univention-directory-manager container/cn create "$@" --ignore_exists \
-        --position "cn=custom attributes,cn=univention,$ldap_base" \
-        --set name=nextcloud
-
-    univention-directory-manager settings/extended_attribute create "$@" \
-        --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="users/user" \
-        --set ldapMapping='nextcloudEnabled' \
-        --set objectClass='nextcloudUser' \
-        --set name='nextcloudUserEnabled' \
-        --set shortDescription='Access to Nextcloud' \
-        --set longDescription='Whether user may access Nextcloud' \
-        --set translationShortDescription='"de_DE" "Zugang für Nextloud"' \
-        --set translationLongDescription='"de_DE" "Der Benutzer kann auf Nextcloud zugreifen"' \
-        --set tabName='Nextcloud' \
-        --set translationTabName='"de_DE" "Nextcloud"' \
-        --set overwriteTab='0' \
-        --set valueRequired='0' \
-        --set CLIName='nextcloudEnabled' \
-        --set syntax='boolean' \
-        --set default="1" \
-        --set tabAdvanced='1' \
-        --set mayChange='1' \
-        --set multivalue='0' \
-        --set deleteObjectClass='0' \
-        --set tabPosition='1' \
-        --set overwritePosition='0' \
-        --set doNotSearch='0' \
-        --set hook='None' || \
-    univention-directory-manager settings/extended_attribute modify "$@" \
-        --dn "cn=nextcloudUserEnabled,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1' \
-        --set default="1" || die "Could not modify nextcloudUserEnabled extended attribute"
-
-    univention-directory-manager settings/extended_attribute create "$@" \
-        --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="users/user" \
-        --set ldapMapping='nextcloudQuota' \
-        --set objectClass='nextcloudUser' \
-        --set name='nextcloudUserQuota' \
-        --set shortDescription='Nextcloud Quota' \
-        --set longDescription='Amount of storage available to the user (ex: 512 MB or 12 GB)' \
-        --set translationShortDescription='"de_DE" "Nextcloud Quota"' \
-        --set translationLongDescription='"de_DE" "Der verfügbare Speicherplatz für den Benutzer (z.B. 512 MB oder 12 GB)"' \
-        --set tabName='Nextcloud' \
-        --set translationTabName='"de_DE" "Nextcloud"' \
-        --set overwriteTab='0' \
-        --set valueRequired='0' \
-        --set CLIName='nextcloudQuota' \
-        --set syntax='string' \
-        --set default="" \
-        --set tabAdvanced='1' \
-        --set mayChange='1' \
-        --set multivalue='0' \
-        --set deleteObjectClass='0' \
-        --set tabPosition='1' \
-        --set overwritePosition='0' \
-        --set doNotSearch='0' \
-        --set hook='None' || \
-    univention-directory-manager settings/extended_attribute modify "$@" \
-        --dn "cn=nextcloudUserQuota,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1' || die "Could not modify nextcloudUserQuota extended attribute"
-
-    univention-directory-manager settings/extended_attribute create "$@" \
-        --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="groups/group" \
-        --set ldapMapping='nextcloudEnabled' \
-        --set objectClass='nextcloudGroup' \
-        --set name='nextcloudGroupEnabled' \
-        --set shortDescription='Available in Nextcloud' \
-        --set longDescription='The group is available in Nextcloud' \
-        --set translationShortDescription='"de_DE" "In Nextcloud verfügbar"' \
-        --set translationLongDescription='"de_DE" "Die Gruppe ist in Nextcloud verfügbar"' \
-        --set tabName='Nextcloud' \
-        --set translationTabName='"de_DE" "Nextcloud"' \
-        --set overwriteTab='0' \
-        --set valueRequired='0' \
-        --set CLIName='nextcloudEnabled' \
-        --set syntax='boolean' \
-        --set default="0" \
-        --set tabAdvanced='0' \
-        --set mayChange='1' \
-        --set multivalue='0' \
-        --set deleteObjectClass='0' \
-        --set tabPosition='1' \
-        --set overwritePosition='0' \
-        --set doNotSearch='0' \
-        --set hook='None' || \
-    univention-directory-manager settings/extended_attribute modify "$@" \
-        --dn "cn=nextcloudGroupEnabled,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1' || die "Could not modify nextcloudGroupEnabled extended attribute"
 }
 
 # Enables all Users that fit the filter to access Nextcloud

--- a/uinst
+++ b/uinst
@@ -27,13 +27,5 @@ joinscript_init
 
 ucs_removeServiceFromLocalhost "${SERVICE}" "$@" || die
 
-if ucs_isServiceUnused "$SERVICE" "$@"; then
-    . /usr/share/univention-lib/ldap.sh
-    eval "$(ucr shell)"
-
-    univention-directory-manager container/cn remove "$@" \
-        --dn "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" || die
-fi
-
 joinscript_remove_script_from_status_file nextcloud
 exit 0


### PR DESCRIPTION
Dear blizzz,

I adjusted the nextcloud joinscript for UCS 4.4 where we want to display the user settings on specific App-Tabs.
See https://forge.univention.org/bugzilla/show_bug.cgi?id=48621.

I hope I didn't interfere with you as I yesterday updated the joinscript on the test appcenter. But it seems now your version is active again.

I also used your new error handling/messages from the currently unmerged pull request.

Best regards
Florian