### PR TITLE
fix certification issue on update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ RUN /bin/bash -c "export DEBIAN_FRONTEND=noninteractive" && \
 	lbzip2 \
 	unattended-upgrades
 
+COPY resources/ldap.conf /etc/ldap/
+
 RUN apt clean
 
 RUN a2enmod headers

--- a/inst
+++ b/inst
@@ -72,7 +72,6 @@ nextcloud_main() {
     nextcloud_modify_users "$@"
     nextcloud_add_Administrator_to_admin_group
     nextcloud_mark_initial_conig_done
-    nextcloud_import_ucs_certificates
     detect_collabora
     detect_onlyoffice
     joinscript_save_current_version
@@ -396,15 +395,6 @@ nextcloud_modify_users() {
             --set nextcloudQuota="$nextcloud_ucs_userQuota" \
             --set serviceprovider="$SP_DN"
     done
-}
-
-nextcloud_import_ucs_certificates () {
-    cat /etc/univention/ssl/ucsCA/CAcert.pem | \
-        docker exec -i "$(ucr get appcenter/apps/nextcloud/container)" \
-            bash -c 'cat > /usr/local/share/ca-certificates/ucs-root-ca.crt'
-    docker exec "$(ucr get appcenter/apps/nextcloud/container)" update-ca-certificates
-    docker exec -i "$(ucr get appcenter/apps/nextcloud/container)" \
-        bash -c "sed -i 's#TLS_CACERT.*#TLS_CACERT /usr/local/share/ca-certificates/ucs-root-ca.crt#' /etc/ldap/ldap.conf"
 }
 
 nextcloud_mark_initial_conig_done() {

--- a/preinst
+++ b/preinst
@@ -40,4 +40,6 @@ EOL
 
 chmod +x "$NC_UCR_FILE"
 
+cp /etc/univention/ssl/ucsCA/CAcert.pem "$NC_PERMCONFDIR/ucs.crt"
+
 exit 0

--- a/resources/ldap.conf
+++ b/resources/ldap.conf
@@ -1,0 +1,1 @@
+TLS_CACERT      /usr/local/share/ca-certificates/ucs.crt

--- a/setup
+++ b/setup
@@ -49,6 +49,9 @@ error_msg() {
 NC_DATADIR="$NC_PERMDATADIR/nextcloud-data"
 NC_UCR_FILE="$NC_PERMCONFDIR/ucr"
 
+mv "$NC_PERMCONFDIR/ucs.crt" /usr/local/share/ca-certificates/ucs.crt 2>&1 | error_msg
+update-ca-certificates 2>&1 | error_msg
+
 cd /var/www/html
 if [ ! -x occ ]; then
 	error_msg "/var/www/html/occ missing or not executable – was the docker container modified manually?"


### PR DESCRIPTION
- the joinscript does not run each update
- ucs already copies the cert into the docker, so we do not need to do it
- ship the config directly in the container

Signed-off-by: Arthur Schiwon <blizzz@arthur-schiwon.de>