### PR TITLE
Add autodetection for ONLYOFFICE Document Server integration edition

### DIFF
--- a/inst
+++ b/inst
@@ -443,7 +443,7 @@ detect_onlyoffice () {
     # If the app is not present, the onlyoffice app is disabled
     FQDN="$(ucr get hostname).$(ucr get domainname)"
     echo "Check for onlyoffice app"
-    if [ "$(ucr get appcenter/apps/onlyoffice-ds/status)" = "installed" ] ; then
+    if [ "$(ucr get appcenter/apps/onlyoffice-ds/status)" = "installed" ] || [ "$(ucr get appcenter/apps/onlyoffice-ds-ie/status)" = "installed" ] ; then
         NC_OFFICE_SUITE=onlyoffice
         univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:enable onlyoffice
         occCode=$?

--- a/inst
+++ b/inst
@@ -443,7 +443,7 @@ detect_onlyoffice () {
     # If the app is not present, the onlyoffice app is disabled
     FQDN="$(ucr get hostname).$(ucr get domainname)"
     echo "Check for onlyoffice app"
-    if [ "$(ucr get appcenter/apps/onlyoffice-ds/status)" = "installed" ] || [ "$(ucr get appcenter/apps/onlyoffice-ds-ie/status)" = "installed" ] ; then
+    if [ "$(ucr get appcenter/apps/onlyoffice-ds/status)" = "installed" ] || [ "$(ucr get appcenter/apps/onlyoffice-ds-integration/status)" = "installed" ] ; then
         NC_OFFICE_SUITE=onlyoffice
         univention-app shell nextcloud sudo -u www-data /var/www/html/occ app:enable onlyoffice
         occCode=$?


### PR DESCRIPTION
For the ONLYOFFICE Document Server Integration Edition the autodetection
needs to work accordingly and activate the ONLYOFFICE plugin in
Nextcloud.

This pull requests adds the proper lines to the join script.