### PR TITLE
Add note about when a new major app update can be expected

### DIFF
--- a/i18n/de/Long Description.html
+++ b/i18n/de/Long Description.html
@@ -80,3 +80,6 @@ Weitere Informationen finden Sie auf <a href="https://nextcloud.com" target="_bl
         Der Web Server ist komplett eingerichtet und steht hinter dem als Reverse Proxy fungierenden und TLS abwickelnden UCS Web Server
     </li>
 </ul>
+<p>
+    Die Nextcloud-App für UCS im Univention App Center basiert auf der neuesten Version aus dem Kanal für stabile Updates von Nextcloud. Major Versionen werden in der Regel innerhalb von 3-6 Monaten nach Veröffentlichung über den stabilen Update-Kanal bereitgestellt. Die App erhält dann auch ein Update im App Center.
+</p>

--- a/i18n/en/Long Description.html
+++ b/i18n/en/Long Description.html
@@ -80,3 +80,6 @@ For more information, visit <a href="https://nextcloud.com" target="_blank">next
         Web server fully configured and behind stock UCS web server acting as proxy and doing all TLS magic
     </li>
 </ul>
+<p>
+    The Nextcloud app for UCS in Univention App Center is based on the latest release from the Nextcloud stable update channel. Major releases are typically provided in the stable update channel within 3-6 month after release. The app will then also receive an update in the App Center.
+</p>


### PR DESCRIPTION
The note about the updates is already published to the latest Nextcloud app description. This pull request takes care that it is not overwritten with the next update.