### PR TITLE
add imagemagick to docker fixes missing SVG support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN /bin/bash -c "export DEBIAN_FRONTEND=noninteractive" && \
 	php-dompdf \
 	php-gd \
 	php-imagick \
+	imagemagick \
 	php-intl \
 	php-mbstring \
 	php-xml \


### PR DESCRIPTION
add imagemagick to docker fix for the error #148
"Module php-imagick in this instance has no SVG support. For better compatibility it is recommended to install it."