### PR TITLE
Use Univention App Center's attributes feature

### DIFF
--- a/attributes
+++ b/attributes
@@ -1,0 +1,64 @@
+[nextcloudUserQuota]
+Description = Nextcloud Quota
+DescriptionDe = Nextcloud Quota
+LongDescription = Amount of storage available to the user (ex: 512 MB or 12 GB)
+LongDescriptionDe = Der verfügbare Speicherplatz für den Benutzer (z.B. 512 MB oder 12 GB)
+Syntax = String
+LdapMapping = nextcloudQuota
+CliName = nextcloudQuota
+Advanced = 1
+TabPosition = 1
+TabName = Nextcloud
+TabNameDe = Nextcloud
+BelongsTo = nextcloudUser
+DeleteObjectClass = 0
+Required = 0
+OverwriteTab = 0
+OverwritePosition = 0
+DontSearch = 0
+Hook = None
+
+[nextcloudUserEnabled]
+Description = Access to Nextcloud
+DescriptionDe = Zugang für Nextloud
+LongDescription = Whether user may access Nextcloud
+LongDescriptionDe = Der Benutzer kann auf Nextcloud zugreifen
+Syntax = Boolean
+UdmSyntax = boolean
+LdapMapping = nextcloudEnabled
+CliName = nextcloudEnabled
+Advanced = 1
+Default = 1
+TabPosition = 1
+TabName = Nextcloud
+TabNameDe = Nextcloud
+BelongsTo = nextcloudUser
+DeleteObjectClass = 0
+Required = 0
+OverwriteTab = 0
+OverwritePosition = 0
+DontSearch = 0
+Hook = None
+
+[nextcloudGroupEnabled]
+Description = Available in Nextcloud
+DescriptionDe = In Nextcloud verfügbar
+LongDescription = The group is available in Nextcloud
+LongDescriptionDe = Die Gruppe ist in Nextcloud verfügbar
+Syntax = Boolean
+UdmSyntax = boolean
+LdapMapping = nextcloudEnabled
+CliName = nextcloudEnabled
+Advanced = 0
+Default = 0
+TabPosition = 1
+TabName = Nextcloud
+TabNameDe = Nextcloud
+BelongsTo = nextcloudGroup
+Module = groups/group
+DeleteObjectClass = 0
+Required = 0
+OverwriteTab = 0
+OverwritePosition = 0
+DontSearch = 0
+Hook = None

--- a/inst
+++ b/inst
@@ -67,8 +67,6 @@ nextcloud_main() {
     fi
     nextcloud_ensure_ucr
     nextcloud_attempt_memberof_support
-    joinscript_register_schema "$@"
-    nextcloud_ensure_extended_attributes "$@"
     nextcloud_configure_saml "$@"
     nextcloud_configure_ldap_backend
     nextcloud_modify_users "$@"
@@ -259,98 +257,6 @@ nextcloud_add_Administrator_to_admin_group() {
 nextcloud_urlEncode() {
   python -c 'import urllib, sys; print urllib.quote(sys.argv[1], sys.argv[2])' \
     "$1" ""
-}
-
-# adds extended attributes to UCS so admins can enable or disable Nextcloud access for users and groups
-nextcloud_ensure_extended_attributes () {
-    univention-directory-manager container/cn create "$@" --ignore_exists \
-        --position "cn=custom attributes,cn=univention,$ldap_base" \
-        --set name=nextcloud
-
-    univention-directory-manager settings/extended_attribute create "$@" \
-        --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="users/user" \
-        --set ldapMapping='nextcloudEnabled' \
-        --set objectClass='nextcloudUser' \
-        --set name='nextcloudUserEnabled' \
-        --set shortDescription='Access to Nextcloud' \
-        --set longDescription='Whether user may access Nextcloud' \
-        --set translationShortDescription='"de_DE" "Zugang für Nextloud"' \
-        --set translationLongDescription='"de_DE" "Der Benutzer kann auf Nextcloud zugreifen"' \
-        --set tabName='Nextcloud' \
-        --set translationTabName='"de_DE" "Nextcloud"' \
-        --set overwriteTab='0' \
-        --set valueRequired='0' \
-        --set CLIName='nextcloudEnabled' \
-        --set syntax='boolean' \
-        --set default="1" \
-        --set tabAdvanced='1' \
-        --set mayChange='1' \
-        --set multivalue='0' \
-        --set deleteObjectClass='0' \
-        --set tabPosition='1' \
-        --set overwritePosition='0' \
-        --set doNotSearch='0' \
-        --set hook='None' || \
-    univention-directory-manager settings/extended_attribute modify "$@" \
-        --dn "cn=nextcloudUserEnabled,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1' \
-        --set default="1" || die "Could not modify nextcloudUserEnabled extended attribute"
-
-    univention-directory-manager settings/extended_attribute create "$@" \
-        --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="users/user" \
-        --set ldapMapping='nextcloudQuota' \
-        --set objectClass='nextcloudUser' \
-        --set name='nextcloudUserQuota' \
-        --set shortDescription='Nextcloud Quota' \
-        --set longDescription='Amount of storage available to the user (ex: 512 MB or 12 GB)' \
-        --set translationShortDescription='"de_DE" "Nextcloud Quota"' \
-        --set translationLongDescription='"de_DE" "Der verfügbare Speicherplatz für den Benutzer (z.B. 512 MB oder 12 GB)"' \
-        --set tabName='Nextcloud' \
-        --set translationTabName='"de_DE" "Nextcloud"' \
-        --set overwriteTab='0' \
-        --set valueRequired='0' \
-        --set CLIName='nextcloudQuota' \
-        --set syntax='string' \
-        --set default="" \
-        --set tabAdvanced='1' \
-        --set mayChange='1' \
-        --set multivalue='0' \
-        --set deleteObjectClass='0' \
-        --set tabPosition='1' \
-        --set overwritePosition='0' \
-        --set doNotSearch='0' \
-        --set hook='None' || \
-    univention-directory-manager settings/extended_attribute modify "$@" \
-        --dn "cn=nextcloudUserQuota,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1' || die "Could not modify nextcloudUserQuota extended attribute"
-
-    univention-directory-manager settings/extended_attribute create "$@" \
-        --position "cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" --set module="groups/group" \
-        --set ldapMapping='nextcloudEnabled' \
-        --set objectClass='nextcloudGroup' \
-        --set name='nextcloudGroupEnabled' \
-        --set shortDescription='Available in Nextcloud' \
-        --set longDescription='The group is available in Nextcloud' \
-        --set translationShortDescription='"de_DE" "In Nextcloud verfügbar"' \
-        --set translationLongDescription='"de_DE" "Die Gruppe ist in Nextcloud verfügbar"' \
-        --set tabName='Nextcloud' \
-        --set translationTabName='"de_DE" "Nextcloud"' \
-        --set overwriteTab='0' \
-        --set valueRequired='0' \
-        --set CLIName='nextcloudEnabled' \
-        --set syntax='boolean' \
-        --set default="0" \
-        --set tabAdvanced='0' \
-        --set mayChange='1' \
-        --set multivalue='0' \
-        --set deleteObjectClass='0' \
-        --set tabPosition='1' \
-        --set overwritePosition='0' \
-        --set doNotSearch='0' \
-        --set hook='None' || \
-    univention-directory-manager settings/extended_attribute modify "$@" \
-        --dn "cn=nextcloudGroupEnabled,cn=nextcloud,cn=custom attributes,cn=univention,$ldap_base" \
-        --set tabAdvanced='1' || die "Could not modify nextcloudGroupEnabled extended attribute"
 }
 
 nextcloud_configure_saml() {


### PR DESCRIPTION
Install the Nextcloud Univention App as a stub using

`univention-app register nextcloud --app --attributes --do-it`

in order to enable NC specific schema and LDAP extended in UCS to serve external (non UCS based) NC installations.

Signed-off-by: Thorsten Roßner <rossner@univention.de>