### PR TITLE
fix(docker): make occ executable again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN cd /root/ && \
 	rm -Rf /root/nextcloud && \
 	rm "nextcloud.tar.bz2" && \
 	cd /var/www/html/ && \
+	chmod +x occ && \
 	chown -R www-data /var/www/html
 
 RUN rm -Rf /var/www/html/apps/updatenotification


### PR DESCRIPTION
For external scripts took advantage of it and are breaking now.