### PR TITLE
release/25.0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@
 
 FROM ubuntu:22.04
 
-ADD https://download.nextcloud.com/server/releases/nextcloud-25.0.9.tar.bz2 /root/nextcloud.tar.bz2
-ADD https://github.com/nextcloud-releases/richdocuments/releases/download/v7.1.4/richdocuments-v7.1.4.tar.gz /root/richdocuments.tar.gz
-ADD https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v7.8.0/onlyoffice.tar.gz /root/onlyoffice.tar.gz
+ADD https://download.nextcloud.com/server/releases/nextcloud-25.0.13.tar.bz2 /root/nextcloud.tar.bz2
+ADD https://github.com/nextcloud-releases/richdocuments/releases/download/v7.1.7/richdocuments-v7.1.7.tar.gz /root/richdocuments.tar.gz
+ADD https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v7.9.2/onlyoffice.tar.gz /root/onlyoffice.tar.gz
 COPY resources/entrypoint.sh /usr/sbin/
 COPY resources/60-nextcloud.ini /etc/php/8.1/apache2/conf.d/
 COPY resources/60-nextcloud.ini /etc/php/8.1/cli/conf.d/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 app_name=nextcloud
-app_version=25.0.9-0
+app_version=25.0.13-0
 app_upgrade_from=24.0.11-0-ucs1
 
 ucs_version=5.0


### PR DESCRIPTION
- [x] test run against RC2 
  - [x] testing fresh install
  - [x] test upgrade
    - [x] from 24
    - [x] from 25
- [x] adapt pr to final
- [x] await final server build to appear on the download server
- [x] build docker image and submit to ucs portal 

## Things found out to document 

- Figured out there is a github action to push (update readme)
  - https://github.com/nextcloud/univention-app/actions/runs/6639888265/job/18039181063
- additional script required for makefile
  - https://provider-portal.software-univention.de/appcenter-selfservice/univention-appcenter-control
  - document login for portal 
  - document usage of test app center
