### PR TITLE
add support for Keycloak / UCS 5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ push-files:
 		i18n/en/README_POST_UPDATE_EN \
 		i18n/de/README_POST_UPDATE_DE
 	univention-appcenter-control set --noninteractive $(ucs_version)/$(app_name)=$(app_version) \
-		--json '{"DockerImage": "ghcr.io/nextcloud/univention-app:$(app_version)", "UMCOptionsAttributes": "nextcloudEnabled", "WebInterface": "/nextcloud", "MinPhysicalRam": "512", "RequiredUcsVersion": "5.0-0", "SupportedUCSVersions": "5.0-0", "RequiredAppVersionUpgrade": "$(app_upgrade_from)"}'
+		--json '{"DockerImage": "ghcr.io/nextcloud/univention-app:$(app_version)", "UMCOptionsAttributes": "nextcloudEnabled", "WebInterface": "/nextcloud", "MinPhysicalRam": "512", "RequiredUcsVersion": "5.0-3", "SupportedUCSVersions": "5.0-3", "RequiredAppVersionUpgrade": "$(app_upgrade_from)"}'
 
 .PHONY: docker
 docker:

--- a/inst
+++ b/inst
@@ -265,7 +265,12 @@ nextcloud_configure_saml() {
     $SETCMD general-require_provisioned_account --value="1"
     $SETCMD general-allow_multiple_user_back_ends --value="1"
 
+
     if ! ucs_needsKeycloakSetup "$@"; then
+        if dpkg --compare-versions "${version_version}" gt "5.0"; then
+            echo "Skipping SAML configuration. No IDP configured for use."
+            return
+        fi
         # SimpleSAMLphp (UCS 5.0 or lower)
         udm saml/serviceprovider create "$@" \
             --ignore_exists \
@@ -289,7 +294,7 @@ nextcloud_configure_saml() {
             --idp-singleLogoutService.url="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/SingleLogoutService.php" \
             --idp-singleSignOnService.url="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/SSOService.php" \
             --idp-entityId="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/metadata.php" \
-            1
+            1 || die "Could not configure simpleSAMLphp as Nextcloud Identity Provider"
     else
         IDP_CERT=$(univention-keycloak "$@" saml/idp/cert get --as-pem --output /dev/stdout)
         SSO_URL="$(univention-keycloak "$@" get-keycloak-base-url)"
@@ -299,12 +304,12 @@ nextcloud_configure_saml() {
             --idp-singleLogoutService.url="$SSO_URL/realms/ucs/protocol/saml" \
             --idp-singleSignOnService.url="$SSO_URL/realms/ucs/protocol/saml" \
             --idp-entityId="$SSO_URL/realms/ucs" \
-            1
+            1 || die "Could not configure Keycloak as Nextcloud Identity Provider"
 
         # Keycloak (starting with UCS 5.1 or optionally manually migrated UCS 5.0)
         univention-keycloak "$@" saml/sp create \
             --metadata-url="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/metadata" \
-            --role-mapping-single-value || die
+            --role-mapping-single-value || die "Could not configure Nextcloud Service Provider as Keycloak"
     fi
 }
 
@@ -317,16 +322,18 @@ nextcloud_modify_users() {
 
     SP_DN=$(univention-ldapsearch -LLL SAMLServiceProviderIdentifier=https://$hostname.$domainname/nextcloud/apps/user_saml/saml/metadata dn | cut -d ' ' -f 2)
 
+    has_simplesamlphp=false
+    if ! ucs_needsKeycloakSetup "$@" && dpkg --compare-versions "${version_version}" lt "5.1"; then
+        has_simplesamlphp=true
+    fi
+
     for dn in $(udm users/user list "$@" --filter "$nextcloud_ucs_modifyUsersFilter" | sed -ne 's/^DN: //p') ; do
         echo "modifying $dn .."
         udm users/user modify "$@" --dn "$dn" \
             --set nextcloudEnabled="$nextcloud_ucs_userEnabled" \
             --set nextcloudQuota="$nextcloud_ucs_userQuota"
 
-        if ! ucs_needsKeycloakSetup "$@"; then
-            udm users/user modify "$@" --dn "$dn" \
-                --append serviceprovider="$SP_DN"
-        fi
+        [ "$has_simplesamlphp" = "true" ] && udm users/user modify "$@" --dn "$dn" --append serviceprovider="$SP_DN"
     done
 }
 

--- a/inst
+++ b/inst
@@ -260,34 +260,52 @@ nextcloud_urlEncode() {
 }
 
 nextcloud_configure_saml() {
-    udm saml/serviceprovider create "$@" \
-        --ignore_exists \
-        --position "cn=saml-serviceprovider,cn=univention,$ldap_base" \
-        --set isActivated=TRUE \
-        --set Identifier="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/metadata" \
-        --set NameIDFormat="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" \
-        --set simplesamlAttributes=TRUE \
-        --set AssertionConsumerService="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/acs" \
-        --set simplesamlNameIDAttribute="uid" \
-        --set singleLogoutService="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/sls" || die
-
-    IDP_CERT=$(curl -s https://"${ucs_server_sso_fqdn:-ucs-sso.$domainname}"/simplesamlphp/saml2/idp/certificate | sed -ne '
-        /-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p      # got the range, ok
-        /-END CERTIFICATE-/q                            # bailing out soon as the cert end seen
-    ')
-
     SETCMD="univention-app shell nextcloud sudo -u www-data php /var/www/html/occ config:app:set user_saml"
     $SETCMD type --value="saml"
     $SETCMD general-require_provisioned_account --value="1"
     $SETCMD general-allow_multiple_user_back_ends --value="1"
 
-    univention-app shell nextcloud sudo -u www-data php /var/www/html/occ saml:config:set \
-        --idp-x509cert="${IDP_CERT}" \
-        --general-uid_mapping="uid" \
-        --idp-singleLogoutService.url="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/SingleLogoutService.php" \
-        --idp-singleSignOnService.url="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/SSOService.php" \
-        --idp-entityId="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/metadata.php" \
-        1
+    if ! ucs_needsKeycloakSetup "$@"; then
+        # SimpleSAMLphp (UCS 5.0 or lower)
+        udm saml/serviceprovider create "$@" \
+            --ignore_exists \
+            --position "cn=saml-serviceprovider,cn=univention,$ldap_base" \
+            --set isActivated=TRUE \
+            --set Identifier="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/metadata" \
+            --set NameIDFormat="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" \
+            --set simplesamlAttributes=TRUE \
+            --set AssertionConsumerService="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/acs" \
+            --set simplesamlNameIDAttribute="uid" \
+            --set singleLogoutService="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/sls" || die
+
+        IDP_CERT=$(curl -s https://"${ucs_server_sso_fqdn:-ucs-sso.$domainname}"/simplesamlphp/saml2/idp/certificate | sed -ne '
+            /-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p      # got the range, ok
+            /-END CERTIFICATE-/q                            # bailing out soon as the cert end seen
+        ')
+
+        univention-app shell nextcloud sudo -u www-data php /var/www/html/occ saml:config:set \
+            --idp-x509cert="${IDP_CERT}" \
+            --general-uid_mapping="uid" \
+            --idp-singleLogoutService.url="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/SingleLogoutService.php" \
+            --idp-singleSignOnService.url="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/SSOService.php" \
+            --idp-entityId="https://${ucs_server_sso_fqdn}/simplesamlphp/saml2/idp/metadata.php" \
+            1
+    else
+        IDP_CERT=$(univention-keycloak "$@" saml/idp/cert get --as-pem --output /dev/stdout)
+        SSO_URL="$(univention-keycloak "$@" get-keycloak-base-url)"
+        univention-app shell nextcloud sudo -u www-data php /var/www/html/occ saml:config:set \
+            --idp-x509cert="${IDP_CERT}" \
+            --general-uid_mapping="uid" \
+            --idp-singleLogoutService.url="$SSO_URL/realms/ucs/protocol/saml" \
+            --idp-singleSignOnService.url="$SSO_URL/realms/ucs/protocol/saml" \
+            --idp-entityId="$SSO_URL/realms/ucs" \
+            1
+
+        # Keycloak (starting with UCS 5.1 or optionally manually migrated UCS 5.0)
+        univention-keycloak "$@" saml/sp create \
+            --metadata-url="https://$hostname.$domainname/nextcloud/apps/user_saml/saml/metadata" \
+            --role-mapping-single-value || die
+    fi
 }
 
 # Enables all Users that fit the filter to access Nextcloud
@@ -303,8 +321,12 @@ nextcloud_modify_users() {
         echo "modifying $dn .."
         udm users/user modify "$@" --dn "$dn" \
             --set nextcloudEnabled="$nextcloud_ucs_userEnabled" \
-            --set nextcloudQuota="$nextcloud_ucs_userQuota" \
-            --append serviceprovider="$SP_DN"
+            --set nextcloudQuota="$nextcloud_ucs_userQuota"
+
+        if ! ucs_needsKeycloakSetup "$@"; then
+            udm users/user modify "$@" --dn "$dn" \
+                --append serviceprovider="$SP_DN"
+        fi
     done
 }
 

--- a/inst
+++ b/inst
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-VERSION=3
+VERSION=4
 SERVICE="Nextcloud"
 
 ARGS=("$@")

--- a/preinst
+++ b/preinst
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+. /usr/share/univention-lib/base.sh
+
 NC_PERMCONFDIR="/var/lib/univention-appcenter/apps/nextcloud/data/integration"
 
 NC_UCR_FILE="$NC_PERMCONFDIR/ucr"
@@ -28,8 +30,8 @@ if [ ! -d "$NC_PERMCONFDIR" ]; then
 fi
 
 cat >"$NC_UCR_FILE" <<EOL
-export NC_HOST_IPS="`ucr dump | grep interfaces | grep address | cut -d ":" -f2`"
-export NC_TRUSTED_PROXY_IP="`ucr get docker/daemon/default/opts/bip | cut -d "/" -f 1`"
+export NC_HOST_IPS="$(get_default_ip_address)"
+export NC_TRUSTED_PROXY_IP="$(ucr get docker/daemon/default/opts/bip | cut -d "/" -f 1)"
 EOL
 
 chmod +x "$NC_UCR_FILE"


### PR DESCRIPTION
Fixes: #204
make the necessary changes to the joinscript to support SAML via SimpleSAMLphp and via Keycloak - depending on what is installed. I tested it successfully on a DC Primary UCS 5.0-10 by just installing nextcloud, then Keycloak, then copy the adjusted joinscript to the system, and force-execute it via: `univention-run-join-scripts --force --run-scripts 50nextcloud.inst`. Afterwards I can successfully login and logout into nextcloud via SAML via Keycloak.