### PR TITLE
fix: add 5.1-0 to supported UCS releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ push-files:
 		i18n/en/README_POST_UPDATE_EN \
 		i18n/de/README_POST_UPDATE_DE
 	univention-appcenter-control set --noninteractive $(ucs_version)/$(app_name)=$(app_version) \
-		--json '{"DockerImage": "ghcr.io/nextcloud/univention-app:$(app_version)", "UMCOptionsAttributes": "nextcloudEnabled", "WebInterface": "/nextcloud", "MinPhysicalRam": "512", "RequiredUcsVersion": "5.0-3", "SupportedUCSVersions": "5.0-3,5.2-0", "RequiredAppVersionUpgrade": "$(app_upgrade_from)"}'
+		--json '{"DockerImage": "ghcr.io/nextcloud/univention-app:$(app_version)", "UMCOptionsAttributes": "nextcloudEnabled", "WebInterface": "/nextcloud", "MinPhysicalRam": "512", "RequiredUcsVersion": "5.0-3", "SupportedUCSVersions": "5.0-3,5.1-0,5.2-0", "RequiredAppVersionUpgrade": "$(app_upgrade_from)"}'
 
 .PHONY: docker
 docker:


### PR DESCRIPTION
otherwise we might block the upgrade from UCS 5.0 to 5.2

With kudos to Univention's Ivan for pointing it out.